### PR TITLE
chore(build): pwa-wrapper as github dependency (fix #12)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "jsdom": "^19.0.0",
         "pdfkit": "^0.13.0",
         "pretty": "^2.0.0",
-        "pwa-wrapper": "file:../PWA-Wrapper",
+        "pwa-wrapper": "hampoelz/PWA-Wrapper#master",
         "svg-to-pdfkit": "^0.1.8"
       },
       "devDependencies": {
@@ -3315,8 +3315,19 @@
       }
     },
     "node_modules/pwa-wrapper": {
-      "resolved": "../PWA-Wrapper",
-      "link": true
+      "version": "1.0.0-beta",
+      "resolved": "git+ssh://git@github.com/hampoelz/PWA-Wrapper.git#4534640443cc76fceafa190b04365f56f261a58d",
+      "license": "MIT",
+      "dependencies": {
+        "compare-versions": "^4.1.3",
+        "custom-electron-titlebar": "^4.0.0",
+        "find-process": "^1.4.7",
+        "lodash": "^4.17.21",
+        "node-fetch": "^2.6.7"
+      },
+      "peerDependencies": {
+        "electron": "^16.0.7"
+      }
     },
     "node_modules/quote-stream": {
       "version": "1.0.2",


### PR DESCRIPTION
Thank you so much for your effort!

However, instead of using a local dependency definition for `pwa-wrapper`, a github URL is used. This enables compiling and running the application on other machines than the developer machine.

Using a local dependency path is only viable for local development as long as the dependency itself is under constant development. IMHO such dependencies should not be published but kept as local change only as they make live hard for other developers.

Such local dependencies do tell anything on the version of the dependency thas has been used, as local changes might be in place that have not been pushed to the repository, yet. 

fixes #12 